### PR TITLE
Grab kni-cluster CR name(space) from environment

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mhrivnak/kni-operator/pkg/apis"
 	"github.com/mhrivnak/kni-operator/pkg/controller"
+	"github.com/mhrivnak/kni-operator/pkg/controller/knicluster"
 
 	osconfigv1 "github.com/openshift/api/config/v1"
 	olmv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
@@ -63,6 +64,12 @@ func main() {
 	logf.SetLogger(zap.Logger())
 
 	printVersion()
+
+	// Check for namespace in env
+	if os.Getenv(knicluster.KNIClusterNamespaceEnv) == "" {
+		log.Error(fmt.Errorf("%s must be defined and not empty", knicluster.KNIClusterNamespaceEnv), "")
+		os.Exit(1)
+	}
 
 	// Get a config to talk to the apiserver
 	cfg, err := config.GetConfig()

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,5 +29,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: KNI_CLUSTER_NAME
+              value: "kni-cluster"
+            - name: KNI_CLUSTER_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             - name: OPERATOR_NAME
               value: "kni-operator"


### PR DESCRIPTION
Instead of hardcoding the name and namespace of the CR to be reconciled,
grab it from environment variables with reasonable defaults.